### PR TITLE
[TASK] add missing typo3/cms - extension-key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
+        },
+        "typo3/cms": {
+            "extension-key": "t3am"
         }
     }
 }


### PR DESCRIPTION
If this isn't added, you'll get n+1 console messages about this option not being present in the package and TYPO3 probably will complain about it later on.